### PR TITLE
[MVP] Numeric Keyboard For Hits

### DIFF
--- a/Code/app/src/main/res/layout/activity_hole1.xml
+++ b/Code/app/src/main/res/layout/activity_hole1.xml
@@ -97,7 +97,7 @@
         android:layout_height="wrap_content"
         android:background="@drawable/rect"
         android:gravity="center"
-        android:inputType="textPersonName"
+        android:inputType="numberPassword"
         android:textColor="#FFFFFF"
         android:textSize="25sp"
         app:layout_constraintBottom_toBottomOf="@+id/imageView"


### PR DESCRIPTION
WHY

- Players should only be able to input numbers for the Hits EditText input
- Switching from alphabetical keyboard to numeric for input creates an unnecessary extra step for the player
- Numeric only keyboard contributes to error handling and prevention by only allowing numeric inputs

HOW
- Modify Hits EditText input type property