### PR TITLE
[MVP] Change Score On Par Click

### DIFF
--- a/Code/app/src/main/java/com/example/swinger/Hole1Activity.java
+++ b/Code/app/src/main/java/com/example/swinger/Hole1Activity.java
@@ -12,11 +12,12 @@ import android.text.SpannableString;
 import android.text.TextWatcher;
 import android.text.style.BackgroundColorSpan;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
-public class Hole1Activity extends AppCompatActivity implements View.OnClickListener {
+public class Hole1Activity extends AppCompatActivity implements OnClickListener {
 
     private Button parBtns[];
     private Button par1;
@@ -29,6 +30,12 @@ public class Hole1Activity extends AppCompatActivity implements View.OnClickList
     private TextView player1;
     private EditText p1Hits;
     private TextView p1score;
+
+    private int calcScoreOnParClick(int par, EditText view){
+        int hits = Integer.parseInt(view.getText().toString());
+        int calcScore = hits - par;
+        return calcScore;
+    }
 
 
 
@@ -45,12 +52,7 @@ public class Hole1Activity extends AppCompatActivity implements View.OnClickList
         par6 = findViewById(R.id.par6Btn);
         player1 = findViewById(R.id.playerOne);
         parBtns = new Button[]{par1,par2,par3,par4,par5,par6};
-        par1.setOnClickListener(this);
-        par2.setOnClickListener(this);
-        par3.setOnClickListener(this);
-        par4.setOnClickListener(this);
-        par5.setOnClickListener(this);
-        par6.setOnClickListener(this);
+
         playerName = getIntent().getStringExtra("playerName");
         player1.setText(playerName);
 
@@ -60,6 +62,13 @@ public class Hole1Activity extends AppCompatActivity implements View.OnClickList
         if(p1Hits==null){
             return;
         }
+
+        par1.setOnClickListener(this);
+        par2.setOnClickListener(this);
+        par3.setOnClickListener(this);
+        par4.setOnClickListener(this);
+        par5.setOnClickListener(this);
+        par6.setOnClickListener(this);
 
         p1Hits.addTextChangedListener(new TextWatcher() {
             @Override
@@ -125,31 +134,37 @@ public class Hole1Activity extends AppCompatActivity implements View.OnClickList
                 clearButtonBackground();
                 par1.setBackgroundResource(R.drawable.par_selected);
                 par1.setTextColor(getColor(R.color.black));
+                p1score.setText(String.valueOf(calcScoreOnParClick(1, p1Hits)));
                 break;
             case R.id.par2Btn:
                 clearButtonBackground();
                 par2.setBackgroundResource(R.drawable.par_selected);
                 par2.setTextColor(getColor(R.color.black));
+                p1score.setText(String.valueOf(calcScoreOnParClick(2, p1Hits)));
                 break;
             case R.id.par3Btn:
                 clearButtonBackground();
                 par3.setBackgroundResource(R.drawable.par_selected);
                 par3.setTextColor(getColor(R.color.black));
+                p1score.setText(String.valueOf(calcScoreOnParClick(3, p1Hits)));
                 break;
             case R.id.par4Btn:
                 clearButtonBackground();
                 par4.setBackgroundResource(R.drawable.par_selected);
                 par4.setTextColor(getColor(R.color.black));
+                p1score.setText(String.valueOf(calcScoreOnParClick(4, p1Hits)));
                 break;
             case R.id.par5Btn:
                 clearButtonBackground();
                 par5.setBackgroundResource(R.drawable.par_selected);
                 par5.setTextColor(getColor(R.color.black));
+                p1score.setText(String.valueOf(calcScoreOnParClick(5, p1Hits)));
                 break;
             case R.id.par6Btn:
                 clearButtonBackground();
                 par6.setBackgroundResource(R.drawable.par_selected);
                 par6.setTextColor(getColor(R.color.black));
+                p1score.setText(String.valueOf(calcScoreOnParClick(6, p1Hits)));
                 break;
             default:
                 break;


### PR DESCRIPTION
WHY
- Players may change the hole par during the game
- Their respective score should change immediately after clicking the par
- Currently score will only update if # of hits changes

HOW
- Modify par button onclick listener to recalculate total score when clicked